### PR TITLE
fix: ffi 2.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/arkatech-ir/open_file_safe
 dependencies:
   flutter:
     sdk: flutter
-  ffi: ^1.0.0
+  ffi: ^2.0.1
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Need ffi 2.0.1 in dependency with open_file_safe 3.2.3 to use file_picker 5.2.5.
